### PR TITLE
Can’t arm when not ready

### DIFF
--- a/custom_components/visonicalarm/alarm_control_panel.py
+++ b/custom_components/visonicalarm/alarm_control_panel.py
@@ -190,15 +190,13 @@ class VisonicAlarm(alarm.AlarmControlPanelEntity):
                 pn.create(self._hass, 'You entered the wrong arm code.', title='Arm Failed')
                 return
 
-        if hub.alarm.ready:
-            hub.alarm.arm_home()
+        process_status_token = hub.alarm.arm_home()
+        sleep(2)
 
-            sleep(1)
-            self.update()
-        else:
-            pn.create(self._hass, 'The alarm system is not in a ready state. '
-                                  'Maybe there are doors or windows open?',
-                      title='Arm Failed')
+        process_status = hub.alarm.get_process_status(process_status_token["process_token"])
+
+        if process_status["status"] == "failed":
+            pn.create(self._hass, process_status["message"], title='Arm Failed')
 
     def alarm_arm_away(self, code=None):
         """ Send arm away command. """
@@ -206,13 +204,11 @@ class VisonicAlarm(alarm.AlarmControlPanelEntity):
             if code != self._code:
                 pn.create(self._hass, 'You entered the wrong arm code.', title='Unable to Arm')
                 return
-            
-        if hub.alarm.ready:
-            hub.alarm.arm_away()
 
-            sleep(1)
-            self.update()
-        else:
-            pn.create(self._hass, 'The alarm system is not in a ready state. '
-                                  'Maybe there are doors or windows open?',
-                      title='Unable to Arm')
+        process_status_token = hub.alarm.arm_away()
+        sleep(2)
+
+        process_status = hub.alarm.get_process_status(process_status_token["process_token"])
+
+        if process_status["status"] == "failed":
+            pn.create(self._hass, process_status["message"], title='Arm Failed')

--- a/custom_components/visonicalarm/manifest.json
+++ b/custom_components/visonicalarm/manifest.json
@@ -4,9 +4,11 @@
   "documentation": "https://github.com/And3rsL/VisonicAlarm-for-Hassio",
   "version": "v3.0.2",
   "requirements": [
-    "visonicalarm2==3.1.0",
+    "git+https://github.com/chrisns/VisonicAlarm2.git@patch-1#visonicalarm2==3.2",
     "python-dateutil==2.7.3"
   ],
   "dependencies": [],
-  "codeowners": ["@And3rsL"]
+  "codeowners": [
+    "@And3rsL"
+  ]
 }


### PR DESCRIPTION
fixes #20
is dependant on https://github.com/And3rsL/VisonicAlarm2/pull/1 and the version of that being bumped
and then you can undo b1de7681a6d4c6ede4fd72bc2bcb7735c9eb695a and put the bumped dependency in the manifest